### PR TITLE
Fix build error by using floats in qMin comparison

### DIFF
--- a/project/widget.cpp
+++ b/project/widget.cpp
@@ -404,7 +404,7 @@ void Widget::drawWheel(QRect r, Wheel *wheel, float alpha)
     QColor color;
     QConicalGradient gradient(QPointF(0, 0), 90);
     for (jack_nframes_t s = 0; s < wheel->sampleCount; s++) {
-        value = qMin(1.0, fabs(*sample)) * alpha;
+        value = qMin(1.0f, fabsf(*sample)) * alpha;
         if (*sample > 0.0) {
             color = QColor::fromHsvF(0.0, 0.0, 1.0, value);
         }


### PR DESCRIPTION
*sample is of type float, which caused fabs to return float.

widget.cpp:407:41: error: no matching function for call to ‘qMin(double, float)’
         value = qMin(1.00, fabs(*sample)) * alpha;