### PR TITLE
add QPainterPath include

### DIFF
--- a/project/widget.cpp
+++ b/project/widget.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QConicalGradient>
 #include <QMessageBox>
 #include <QDebug>


### PR DESCRIPTION
Build broke in Qt 5.15 due to QPainterPath no longer being pulled in by another include.