### PR TITLE
QPainterPath was not defined, needs to be included

### DIFF
--- a/project/widget.cpp
+++ b/project/widget.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QConicalGradient>
 #include <QMessageBox>
 #include <QDebug>


### PR DESCRIPTION
I got the following error, when compiling on arch linux on Qt version 5.15.3:

> widget.cpp: In member function ‘void Widget::drawWheel(QRect, Wheel*, float)’:
> widget.cpp:419:18: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
>   419 |     QPainterPath path;
>       |                  ^~~~
> widget.cpp:421:18: error: aggregate ‘QPainterPath hole’ has incomplete type and cannot be defined
>   421 |     QPainterPath hole;
>       |                  ^~~~

Maybe in a prior version of Qt, it wasn't necessary to also include <QPainterPath>, but apparently now it is necessary to include <QPainterPath> in addition to <QPainter>.